### PR TITLE
Fix help text for cpu_allocation and memory_allocation metrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -8,9 +8,9 @@ var metricHelp = map[string]string{
 	"gather_time":  "duration of last gathering run, in seconds",
 
 	// xapi derived metrics
-	"cpu_count":         "the number of physical CPUs on the host",
-	"cpu_pct_allocated": "percent vCPUs over total CPUs on this host",
-	"default_storage":   "true if SR is a default SR for a pool, otherwise false",
+	"cpu_count":       "the number of physical CPUs on the host",
+	"cpu_allocation":  "percent vCPUs over total CPUs on this host",
+	"default_storage": "true if SR is a default SR for a pool, otherwise false",
 	"ha_allow_overcommit": "If set to false then operations which would cause " +
 		"the Pool to become overcommitted will be blocked.",
 	"ha_enabled": "true if HA is enabled on the pool, false otherwise",
@@ -20,7 +20,7 @@ var metricHelp = map[string]string{
 		"i.e. if there exist insufficient physicalk resources to tolerate the " +
 		"configured number of host failures",
 	"memory_free":            "Free host memory (bytes)",
-	"memory_pct_allocated":   "percent used memory over total memory on this host",
+	"memory_allocation":      "percent used memory over total memory on this host",
 	"memory_total":           "Total host memory (bytes)",
 	"physical_pct_allocated": "percent of physical_utilisation over physical_size",
 	"physical_size":          "total physical size of the repository (in bytes)",


### PR DESCRIPTION
Thank you for open sourcing this! This PR fixes the help text for the `cpu_allocation` and `memory_allocation` metrics [here](https://github.com/johnprather/xapi_exporter/blob/master/exporter.go#L197) and [here](https://github.com/johnprather/xapi_exporter/blob/master/exporter.go#L221).

Alternatively, I could rename `cpu_allocation` and `memory_allocation` to `cpu_pct_allocated` and `memory_pct_allocated` to match the help text and the `physical_pct_allocated` for consistency if you prefer.